### PR TITLE
Add more tools to investigate links data

### DIFF
--- a/bin/compare
+++ b/bin/compare
@@ -4,3 +4,5 @@ require './lib/database'
 
 database = Database.new
 database.compare!
+puts
+database.summarise_missing_publishing_api_link_types!

--- a/bin/import
+++ b/bin/import
@@ -7,7 +7,9 @@ class Import
   def import!
     data_importer = DataImporter.new
 
-    data_importer.import_data_from_publishing_api if import_publishing_api?
+    data_importer.import_links_from_publishing_api if import_publishing_api?
+    data_importer.import_content_from_publishing_api if import_publishing_api?
+
     data_importer.import_data_from_rummager if import_rummager?
   end
 

--- a/bin/mismatched_content
+++ b/bin/mismatched_content
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require './lib/database'
+
+database = Database.new
+database.find_unmatched_base_paths!

--- a/bin/missing_app_links
+++ b/bin/missing_app_links
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require './lib/database'
+
+if ARGV.length < 1
+  $stderr.puts "Usage: missing_app_links PUBLISHING_APP"
+  exit(1)
+end
+
+database = Database.new
+database.find_missing_publishing_api_link_types!(publishing_app: ARGV.first)

--- a/lib/data_importer.rb
+++ b/lib/data_importer.rb
@@ -1,5 +1,6 @@
 require './lib/database'
 require './lib/fetch_publishing_api_links'
+require './lib/fetch_publishing_api_content'
 require './lib/fetch_rummager'
 require './lib/rummager_data_presenter'
 
@@ -9,7 +10,7 @@ class DataImporter
     @database = Database.new
   end
 
-  def import_data_from_publishing_api
+  def import_links_from_publishing_api
     create_publishing_api_table
 
     publishing_api = FetchPublishingApiLinks.new
@@ -17,6 +18,20 @@ class DataImporter
     data = publishing_api.request_data!
 
     @database.copy_rows(table_name: 'publishing_api') do
+      data.each_row do |row|
+        @database.copy_row(row)
+      end
+    end
+  end
+
+  def import_content_from_publishing_api
+    create_publishing_api_content_table
+
+    publishing_api = FetchPublishingApiContent.new
+
+    data = publishing_api.request_data!
+
+    @database.copy_rows(table_name: 'api_content') do
       data.each_row do |row|
         @database.copy_row(row)
       end
@@ -55,6 +70,21 @@ class DataImporter
         'link_type text',
         'link_content_ids text',
         'link_base_paths text[]',
+      ]
+    )
+  end
+
+  def create_publishing_api_content_table
+    puts "creating publishing api content table..."
+
+    @database.create_table(
+      table_name: 'api_content',
+      columns: [
+        'content_id text',
+        'base_path text',
+        'format text',
+        'publishing_app text',
+        'routes text',
       ]
     )
   end

--- a/lib/fetch_publishing_api_content.rb
+++ b/lib/fetch_publishing_api_content.rb
@@ -1,0 +1,24 @@
+class FetchPublishingApiContent
+
+  def initialize
+    @connection = PG.connect(ENV["DATABASE_URL"] || 'postgresql:///publishing_api_development')
+  end
+
+  def request_data!
+    query = <<-QUERY
+    SELECT
+      content.content_id,
+      locations.base_path,
+      content.format,
+      content.publishing_app,
+      (content.routes)->0->>'path'
+    FROM
+      content_items content
+      join states on states.content_item_id = content.id and states.name='published'
+      join locations on locations.content_item_id = content.id
+      join translations on translations.content_item_id = content.id and translations.locale = 'en'
+    QUERY
+
+    @connection.exec(query)
+  end
+end


### PR DESCRIPTION
When we look at links that are missing from the publishing api but
are in rummager, we would like to know a bit more about what published
them.

Added a new table containing metadata about the content (not the links)
from the publishing api, so we can reference this in our queries.

`bin/compare` previously only showed link_types that we found in both
rummager and publishing api.

Now we also look at link types that are not present in publishing api at
all. In some cases (specialist publisher) this is because we haven't
migrated them yet. We may also have false positives because we are
not matching content properly.

`./bin/compare` now shows a breakdown by app of this missing data.

`./bin/missing_app_links` allows you to extract a list by app

`./bin/mismatched_content` shows the content we failed to match by base path (about 2000 items)
