### PR TITLE
Script to show content items with missing topics

### DIFF
--- a/bin/missing_topics_and_browse
+++ b/bin/missing_topics_and_browse
@@ -1,6 +1,24 @@
 #!/usr/bin/env ruby
 
+require 'optparse'
 require './lib/database'
 
+options = {format: :text}
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: example.rb [options]"
+
+  opts.on("-fFORMAT", [:csv, :text], "--format=FORMAT") do |form|
+    options[:format] = form
+
+  end
+end
+
+begin
+  parser.parse!
+rescue OptionParser::InvalidOption => error
+  die error.message, :usage => true
+end
+
 database = Database.new
-database.find_missing_topics_and_browse!
+database.find_missing_topics_and_browse!(output: options[:format])

--- a/bin/missing_topics_and_browse
+++ b/bin/missing_topics_and_browse
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require './lib/database'
+
+database = Database.new
+database.find_missing_topics_and_browse!

--- a/lib/database.rb
+++ b/lib/database.rb
@@ -52,7 +52,8 @@ class Database
   end
 
   # Identify rummager content that is not in the publishing api.
-  # This content is ignored in other queries.
+  # If the target of a link is not in the publishing api it gets
+  # ignored by the other queries.
   def find_unmatched_base_paths!
     query = <<-SQL
       SELECT DISTINCT base_path FROM rummager
@@ -106,6 +107,44 @@ class Database
     end
 
     puts "#{results.ntuples} missing #{publishing_app} links found"
+  end
+
+  # All items with missing topics or browse pages
+  def find_missing_topics_and_browse!
+    query = <<-SQL
+      WITH missing_links as (
+        SELECT
+          base_path, link_type
+        FROM rummager
+        WHERE link_type in ('topics', 'mainstream_browse_pages')
+
+        EXCEPT
+
+        SELECT
+          base_path,link_type
+        FROM publishing_api
+        WHERE link_type in ('topics', 'mainstream_browse_pages')
+      )
+
+      SELECT base_path, link_type, format, publishing_app
+      FROM
+        missing_links
+      JOIN
+        api_content USING(base_path)
+    SQL
+
+    results = @connection.exec(query)
+
+    puts "MISSING TOPICS AND MAINSTREAM_BROWSE_PAGES:"
+
+    results.each_row do |row|
+      %w(base_path link_type format publishing_app).zip(row).each do |name, value|
+        puts ("%-20s " % name) + value
+      end
+      puts '------------------------------'
+    end
+
+    puts "#{results.ntuples} rows found"
   end
 
   def summarise_missing_publishing_api_link_types!


### PR DESCRIPTION
Finds all content items that have topics or mainstream browse pages in rummager but don't in publishing api.

cc @MatMoore 
cc @alphagov/team-finding-things 
