### PR TITLE
Reduce the batch size limit for rummager

### DIFF
--- a/lib/fetch_rummager.rb
+++ b/lib/fetch_rummager.rb
@@ -3,7 +3,7 @@ require 'active_support'
 require 'active_support/core_ext/object/blank'
 
 class FetchRummager
-  BATCH_SIZE = 3500
+  BATCH_SIZE = 1000
 
   def initialize
     @endpoint = ENV["RUMMAGER_URL"] || 'http://rummager.dev.gov.uk/unified_search.json'


### PR DESCRIPTION
Given https://github.com/alphagov/rummager/pull/634
We can only request a maximum of 1000 records
