### PR TITLE
Add known problems to whitelist

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -15,10 +15,39 @@
 #      expiry: '2016-05-22'
 #      reason: "service-manual (and one extra page) is not fully baked yet, but we'll be ready to handle it soon"
 
-BasePathsMissingFromPublishingApi:
+
+#BasePathsMissingFromRummager:
+#BasePathsMissingFromPublishingApi:
+#LinkedBasePathsMissingFromPublishingApi:
+#RummagerLinksNotIndexedInRummager:
+
+LinkedBasePathsMissingFromPublishingApi:
   rules:
     - predicate:
-      - index: 'service-manual'
-        format: 'manual_section'
-      expiry: '2016-06-22'
-      reason: "service-manual is not fully baked yet, but we'll be ready to handle it soon"
+      - link_type: 'people'
+      expiry: '2017-06-01'
+      reason: "We're not going to look at people links for a long time - let's reassess next year"
+
+LinksMissingFromRummager:
+  rules:
+    - predicate:
+      - link_type: 'people'
+      expiry: '2017-06-01'
+      reason: "We're not going to look at people links for a long time - let's reassess next year"
+
+LinksMissingFromPublishingApi:
+  rules:
+    - predicate:
+      - link_type: 'people'
+      expiry: '2017-06-01'
+      reason: "We're not going to look at people links for a long time - let's reassess next year"
+    - predicate:
+      - link_type: 'organisations'
+      expiry: '2016-07-01'
+      reason: |
+        We're looking at problems with organisations tagging already:
+        https://trello.com/c/aOTMr3WJ/640-whitehall-organisations-tagged-to-itself
+        https://trello.com/c/us3MI1n9/602-fix-organisation-tagging
+        https://trello.com/c/ZaFLDY1E/638-fix-rummager-publishing-api-discrepancy-for-guidance-publication
+        https://trello.com/c/oqjOp8jd/639-specialist-publisher-documents-don-t-have-organisations-in-the-publishing-api
+        https://trello.com/c/5aTIhKur/641-publisher-organisation-tagging-not-in-sync-between-rummager-and-publishing-api


### PR DESCRIPTION
Whitelist 'people' link_type, on all the checks where
link_type is part of the output.

Whitelist 'organisations' link_type, only for links in
Rummager but not in Publishing API, for now - several
investigations/fixes are ongoing.
