### PR TITLE
Add documentation for individual checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The exit code for a run is `1` if any check fails, `0` otherwise.
 Each check can filter its usual output using a whitelist. This allows us to run the checks automatically
 in Jenkins and still keep the job green even though there may be some known problems we are working on.
 
+Each check's purpose and way of working should be described in the [checks readme](lib/checks/README.md) 
+
 ### Dependencies
 
 - [publishing api](https://github.com/alphagov/publishing-api)

--- a/lib/checks/README.md
+++ b/lib/checks/README.md
@@ -1,0 +1,59 @@
+## Check Form
+
+A check always has the same input and output types.
+
+Input:
+
+- check name
+- checker database, for access to imported data
+- whitelist, for access to output filtering rules for the check
+
+Output:
+
+- a report object, including csv output for writing to a file
+
+Each check is independent of the others and has a single purpose.
+However, they may have overlapping output, in that several checks may detect the same content discrepancy.
+
+## Checks
+
+### BasePathsMissingFromPublishingApi
+
+This check finds content present in Rummager for which the base_path doesn't map to a published content item in the Publishing API.
+The assumption is that anything present in Rummager should be published.
+Our proxy for 'being published' is that the `/lookup-by-base-path` endpoint in Publishing API finds a content_id.
+Recommended links are excluded.
+
+### BasePathsMissingFromRummager
+
+This check finds published content present in Publishing API for which no base_path is present in Rummager.
+The assumption is that everything published in Publishing API should be in Rummager.
+Our proxy for 'being published' is that the some content item of the content_id is state `published`, `unpublished`, or `superseded`.
+
+### LinkedBasePathsMissingFromPublishingApi
+
+This check finds link targets for links present in Rummager for which the target base_path doesn't map to a published content item in the Publishing API.
+The assumption is that any link target in Rummager should be published.
+Our proxy for 'being published' is that the `/lookup-by-base-path` endpoint in Publishing API finds a content_id.
+
+### RummagerLinksNotIndexedInRummager
+
+This check finds link targets for links present in Rummager for which the target base_path is not present in Rummager.
+The assumption is that any link target in Rummager should be indexed.
+
+### LinksMissingFromPublishingApi
+
+This check finds links present in Rummager which are not present in Publishing API.
+The assumption is that links should always be in sync.
+
+### LinksMissingFromRummager
+
+This check finds links present in Publishing API which are not present in Rummager.
+The assumption is that links should always be in sync.
+
+### ExpiredWhitelistEntries
+
+This check doesn't check anything about Rummager or Publishing API.
+Instead, it reports on whitelist entries which have expired.
+This is so that when the checks are running automatically in Jenkins, we are eventually reminded of discrepancies we previously whitelisted.
+We should provide a reason and a sensible recheck time when we add a whitelist entry.

--- a/lib/checks/base_paths_missing_from_publishing_api.rb
+++ b/lib/checks/base_paths_missing_from_publishing_api.rb
@@ -6,8 +6,6 @@ module Checks
       @whitelist = whitelist
     end
 
-    # find base_paths present in Rummager which don't map to a published content item in the Publishing API
-
     def run_check
       query = <<-SQL
       SELECT

--- a/lib/checks/base_paths_missing_from_rummager.rb
+++ b/lib/checks/base_paths_missing_from_rummager.rb
@@ -6,12 +6,6 @@ module Checks
       @whitelist = whitelist
     end
 
-    # find content_ids present in Publishing API which have a published content item
-    # and for which no base_path is present in Rummager
-
-    # assumption for now: if any content_item was ever published under this content_id,
-    # then we should have it in Rummager; otherwise, we shouldn't care.
-
     def run_check
       query = <<-SQL
       SELECT

--- a/lib/checks/expired_whitelist_entries.rb
+++ b/lib/checks/expired_whitelist_entries.rb
@@ -6,8 +6,6 @@ module Checks
       @whitelist = whitelist
     end
 
-    # find whitelist entries which have expired
-
     def run_check
       headers = %w(check_name expiry_date reason)
       expiries = @whitelist.report_expired_entries(Date.today)

--- a/lib/checks/linked_base_paths_missing_from_publishing_api.rb
+++ b/lib/checks/linked_base_paths_missing_from_publishing_api.rb
@@ -6,9 +6,6 @@ module Checks
       @whitelist = whitelist
     end
 
-    # find content_ids for base_paths present in links in Rummager which
-    # don't map to a published content item in the Publishing API
-
     def run_check
       query = <<-SQL
       SELECT

--- a/lib/checks/links_missing_from_publishing_api.rb
+++ b/lib/checks/links_missing_from_publishing_api.rb
@@ -6,8 +6,6 @@ module Checks
       @whitelist = whitelist
     end
 
-    # find links present in Rummager which are not present in Publishing API
-
     def run_check
       publishing_api_links_query = <<-SQL
       SELECT

--- a/lib/checks/links_missing_from_rummager.rb
+++ b/lib/checks/links_missing_from_rummager.rb
@@ -6,8 +6,6 @@ module Checks
       @whitelist = whitelist
     end
 
-    # find links present in Publishing API which are not present in Rummager
-
     def run_check
       publishing_api_links_query = <<-SQL
       SELECT

--- a/lib/checks/rummager_links_not_indexed_in_rummager.rb
+++ b/lib/checks/rummager_links_not_indexed_in_rummager.rb
@@ -6,9 +6,6 @@ module Checks
       @whitelist = whitelist
     end
 
-    # find base_paths linked to from Rummager items which are not themselves indexed in Rummager
-    # For example, in the past a removed organisation was correctly deindexed but was not removed from all link sets
-
     def run_check
       query = <<-SQL
       SELECT


### PR DESCRIPTION
Centralises and clarifies previous comments into a readme.
