### PR TITLE
Make `run_automated_checks` suitable for CI

### DIFF
--- a/bin/run_automated_checks
+++ b/bin/run_automated_checks
@@ -2,7 +2,5 @@
 
 set -e
 
-bundle install
-
 # all checks get run if none are specified
-govuk_setenv rummager bundle exec bin/run_checks.rb
+bundle exec bin/run_checks.rb


### PR DESCRIPTION
- Don't `bundle install`, Jenkins already does that
- Don't `govuk_setenv rummager` because the rummager env is not available
