### PR TITLE
Use gds-api-adapters for publishing-api requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'sqlite3'
-gem 'unirest'
 gem 'gds-api-adapters', '~> 30.6.0'
 gem 'thread'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,6 @@ GEM
     hashdiff (0.3.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    json (1.8.3)
     link_header (0.0.8)
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
@@ -73,10 +72,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.2)
     unicode-display_width (1.0.5)
-    unirest (1.0.8)
-      addressable
-      json
-      rest-client
     webmock (2.0.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -91,7 +86,6 @@ DEPENDENCIES
   rspec
   sqlite3
   thread
-  unirest
   webmock
 
 BUNDLED WITH

--- a/lib/check_runner.rb
+++ b/lib/check_runner.rb
@@ -2,7 +2,6 @@ class CheckRunner
   def initialize(env, *check_names)
     Thread.abort_on_exception = true
 
-    publishing_api_url = Plek.find('publishing-api') + '/v2/grouped-content-and-links'
     checker_db_name = env["CHECKER_DB_NAME"] || CheckerDB.in_memory_db_name
     skip_import = env["SKIP_DATA_IMPORT"] ? true : false
     whitelist_file = env["WHITELIST_FILE"] || 'whitelist.yml'
@@ -17,7 +16,7 @@ class CheckRunner
     @importers = []
     unless skip_import
       @importers << Import::RummagerImporter.new(checker_db, @progress_reporter)
-      @importers << Import::PublishingApiImporter.new(checker_db, @progress_reporter, publishing_api_url)
+      @importers << Import::PublishingApiImporter.new(checker_db, @progress_reporter)
     end
 
     @checks = load_checks(checker_db, whitelist, check_names)

--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -1,7 +1,7 @@
 require 'sqlite3'
-require 'unirest'
 require 'gds_api/rummager'
 require 'gds_api/publishing_api_v2'
+require 'services'
 require 'thread/pool'
 require 'thread/future'
 require 'csv'

--- a/lib/import/publishing_api_importer.rb
+++ b/lib/import/publishing_api_importer.rb
@@ -1,9 +1,8 @@
 module Import
   class PublishingApiImporter
-    def initialize(checker_db, progress_reporter, publishing_api_url)
+    def initialize(checker_db, progress_reporter)
       @checker_db = checker_db
       @thread_pool = Thread.pool(1)
-      @publishing_api_url = publishing_api_url
       @progress_reporter = progress_reporter
     end
 
@@ -71,13 +70,10 @@ module Import
     end
 
     def do_request(last_seen_content_id)
-      url = "#{@publishing_api_url}?page_size=#{BATCH_SIZE}&last_seen_content_id=#{last_seen_content_id}"
-
-      response = Unirest.get(url)
-      if response.code != 200 || !response.body["results"]
-        raise "bad response: #{response.code}\n#{response.raw_body}"
-      end
-      response.body
+      Services.publishing_api.get_grouped_content_and_links(
+        last_seen_content_id: last_seen_content_id,
+        page_size: BATCH_SIZE
+      )
     end
 
     def import_content(row)

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,29 @@
+module Services
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+      timeout: 20,
+    )
+  end
+
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(
+      Plek.new.find('rummager'),
+      timeout: 20,
+    )
+  end
+end
+
+# This will move to gds-api-adapters once we have a generalised use case.
+class GdsApi::PublishingApiV2
+  def get_grouped_content_and_links(last_seen_content_id: nil, page_size: nil)
+    params = {}
+    params["last_seen_content_id"] = last_seen_content_id unless last_seen_content_id.nil?
+    params["page_size"] = page_size unless page_size.nil?
+
+    query = query_string(params)
+
+    get_json!("#{endpoint}/v2/grouped-content-and-links#{query}")
+  end
+end


### PR DESCRIPTION
This allows us to use the bearer token, which is needed in integration.
