### PR TITLE
Don't report `expected_total` for import progress

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,2 @@
 AllCops:
   TargetRubyVersion: 2.3
-

--- a/lib/import/publishing_api_importer.rb
+++ b/lib/import/publishing_api_importer.rb
@@ -52,18 +52,14 @@ module Import
       response = do_request(NIL_UUID)
       results = response["results"]
 
-      # We currently don't have a way in the publishing api to get the expected count of content_ids.
-      # We hardcode a guess just to make the progress reporting slightly nicer during development.
-      expected_total = 602365
-
-      @progress_reporter.report('publishing api import', expected_total, 0, 'just starting')
+      @progress_reporter.report('publishing api import', 0, 'just starting')
 
       running_total = results ? results.size : 0
 
       while results && !results.empty? do
         running_total += results.size
         yield results
-        @progress_reporter.report('publishing api import', expected_total, running_total, 'importing...')
+        @progress_reporter.report('publishing api import', running_total, 'importing...')
         response = do_request(response['last_seen_content_id'])
         results = response["results"]
       end

--- a/lib/import/rummager_importer.rb
+++ b/lib/import/rummager_importer.rb
@@ -65,8 +65,7 @@ module Import
 
     def import_rummager_batches
       offset = 0
-      expected_total_docs = get_total_document_count
-      @progress_reporter.report('rummager import', expected_total_docs, 0, 'just starting')
+      @progress_reporter.report('rummager import', 0, 'just starting')
 
       results = do_request(offset)
 
@@ -74,7 +73,7 @@ module Import
         yield results
         offset += results.size
         results = do_request(offset)
-        @progress_reporter.report('rummager import', expected_total_docs, offset, 'importing...')
+        @progress_reporter.report('rummager import', offset, 'importing...')
       end
     end
 
@@ -124,10 +123,6 @@ module Import
       SQL
       missing_links_base_paths = @checker_db.execute(query).flatten
       import_base_path_mappings(missing_links_base_paths)
-    end
-
-    def get_total_document_count
-      Services.rummager.unified_search(count: 0).total
     end
   end
 end

--- a/lib/progress_reporter.rb
+++ b/lib/progress_reporter.rb
@@ -3,10 +3,10 @@ class ProgressReporter
     @mutex = Mutex.new
   end
 
-  def report(task, expected_total, running_total, message)
+  def report(task, running_total, message)
     @mutex.synchronize do
       prefix = "#{task} progress:".ljust(40, ' ')
-      counts = "#{running_total}/#{expected_total} (#{'%.2f' % (100 * (running_total.to_f / expected_total))}%)".rjust(30, ' ')
+      counts = "#{running_total} done".rjust(30, ' ')
       puts "#{prefix}#{counts} - #{message}"
     end
   end


### PR DESCRIPTION
This is misleading, as there are currently more than `602365` items and the console is reporting:

```
publishing api import progress:                681431/602365 (113.13%)
- importing...
```
