### PR TITLE
Add more to whitelist

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -35,7 +35,6 @@ BasePathsMissingFromRummager:
       expiry: '3000-01-01'
       reason: "Rummager indexes the new link, not the old one"
 
-
     - predicate:
       - format: 'taxon'
       expiry: '2017-01-01'
@@ -47,6 +46,11 @@ BasePathsMissingFromRummager:
       expiry: '3000-01-01'
       reason: "Topic main page"
 
+    - predicate:
+      - publishing_app: 'whitehall'
+        format: 'html_publication'
+      expiry: '2017-01-01'
+      reason: "We don't currently index html attachments (but perhaps we should?)"
 
 BasePathsMissingFromPublishingApi:
   rules:
@@ -69,6 +73,40 @@ LinksMissingFromRummager:
       - link_type: 'people'
       expiry: '2017-06-01'
       reason: "We're not going to look at people links for a long time - let's reassess next year"
+
+    - predicate:
+      - format: 'email_alert_signup'
+      - format: 'special_route'
+      - format: 'financial_releases_geoblocker'
+      - format: 'finder_email_signup'
+      - format: 'financial_release'
+      - format: 'financial_releases_campaign'
+      expiry: '3000-01-01'
+      reason: "Format doesn't contain searchable information"
+
+    - predicate:
+      - format: 'redirect'
+      - format: 'gone'
+      - format: 'unpublishing'
+      expiry: '3000-01-01'
+      reason: "Rummager indexes the new link, not the old one"
+
+    - predicate:
+      - format: 'taxon'
+      expiry: '2017-01-01'
+      reason: "Taxon is a new thing and shouldn't be visible to users"
+
+    - predicate:
+      - format: 'topic'
+        content_id: '76e9abe7-dac8-49f0-bb5e-53e4b0d2cdba'
+      expiry: '3000-01-01'
+      reason: "Topic main page"
+
+    - predicate:
+      - publishing_app: 'whitehall'
+        format: 'html_publication'
+      expiry: '2017-01-01'
+      reason: "We don't currently index html attachments (but perhaps we should?)"
 
 RummagerLinksNotIndexedInRummager:
   rules:


### PR DESCRIPTION
Exclude html_publications, since we don't index them
Exclude things we will never handle in Rummager for the
links check as well as the base_path check
