### PR TITLE
Add operational_field to whitelist

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -57,17 +57,16 @@ BasePathsMissingFromRummager:
       expiry: '3000-01-01'
       reason: "These are internal links added by recommended links. Don't belong in Publishing API."
 
-    - predicate:
-      - format: operational_field
-      expiry: '2016-07-01'
-      reason: "Being worked on: https://trello.com/c/az1N1nut"
-
 BasePathsMissingFromPublishingApi:
   rules:
     - predicate:
       - index: 'service-manual'
       expiry: '2016-08-14'
       reason: "We don't think any service manual content has made it into publishing-api yet - it's being rewritten"
+    - predicate:
+      - format: operational_field
+      expiry: '2016-07-01'
+      reason: "Being worked on: https://trello.com/c/0UAMj5gj"
 
 
 LinkedBasePathsMissingFromPublishingApi:


### PR DESCRIPTION
- Add to BasePathsMissingFromPublishingApi whitelist. Core Formats are
  planning to fix this in the short term.
- Remove a similar entry from BasePathsMissingFromRummager -
  operational_field items are present in Rummager.
