### PR TITLE
Don't persist rummager's `document_type`

### DIFF
--- a/lib/checks/base_paths_missing_from_publishing_api.rb
+++ b/lib/checks/base_paths_missing_from_publishing_api.rb
@@ -11,15 +11,14 @@ module Checks
       SELECT
         rc.base_path,
         rc.format,
-        rc.rummager_index,
-        rc.document_type
+        rc.rummager_index
       FROM rummager_content rc
       LEFT JOIN rummager_base_path_content_id lookup ON rc.base_path = lookup.base_path
       WHERE lookup.content_id IS NULL
       AND format NOT IN ('recommended-link')
       SQL
 
-      headers = %w(base_path format index document_type)
+      headers = %w(base_path format index)
       rows = @checker_db.execute(query)
       @reporter.create_report(@name, headers, rows)
     end

--- a/lib/checks/linked_base_paths_missing_from_publishing_api.rb
+++ b/lib/checks/linked_base_paths_missing_from_publishing_api.rb
@@ -13,15 +13,14 @@ module Checks
         rl.link_type,
         rl.base_path,
         rc.format,
-        rc.rummager_index,
-        rc.document_type
+        rc.rummager_index
       FROM rummager_link rl
       LEFT JOIN rummager_base_path_content_id lookup ON rl.link_base_path = lookup.base_path
       JOIN rummager_content rc ON rc.base_path = rl.base_path
       WHERE lookup.content_id IS NULL
       SQL
 
-      headers = %w(link link_type item item_format item_index item_document_type)
+      headers = %w(link link_type item item_format item_index)
       rows = @checker_db.execute(query)
       @reporter.create_report(@name, headers, rows)
     end

--- a/lib/checks/rummager_links_not_indexed_in_rummager.rb
+++ b/lib/checks/rummager_links_not_indexed_in_rummager.rb
@@ -13,15 +13,14 @@ module Checks
         rl.link_type,
         rl.base_path,
         rc_item.format,
-        rc_item.rummager_index,
-        rc_item.document_type
+        rc_item.rummager_index
       FROM rummager_link rl
       LEFT JOIN rummager_content rc ON rc.base_path = rl.link_base_path
       JOIN rummager_content rc_item ON rc_item.base_path = rl.base_path
       WHERE rc.base_path IS NULL
       SQL
 
-      headers = %w(link link_type item item_format item_index item_document_type)
+      headers = %w(link link_type item item_format item_index)
       rows = @checker_db.execute(query)
       @reporter.create_report(@name, headers, rows)
     end

--- a/lib/import/rummager_data_presenter.rb
+++ b/lib/import/rummager_data_presenter.rb
@@ -7,7 +7,6 @@ module Import
           item['content_id'],
           item['format'],
           item['index'],
-          item['document_type']
         ]
       end
     end

--- a/lib/import/rummager_importer.rb
+++ b/lib/import/rummager_importer.rb
@@ -38,7 +38,6 @@ module Import
           'content_id text',
           'format text',
           'rummager_index text',
-          'document_type text',
         ],
         index: ['base_path']
       )
@@ -89,7 +88,7 @@ module Import
     def import_content(rows)
       @checker_db.insert_batch(
         table_name: 'rummager_content',
-        column_names: %w(base_path content_id format rummager_index document_type),
+        column_names: %w(base_path content_id format rummager_index),
         rows: rows
       )
     end

--- a/spec/import/rummager_data_presenter_spec.rb
+++ b/spec/import/rummager_data_presenter_spec.rb
@@ -20,7 +20,7 @@ module Import
       batch_data = [test_data_example]
 
       expected_rows = [
-          ['/vehicle-tax', nil, 'transaction', 'mainstream', 'edition'],
+          ['/vehicle-tax', nil, 'transaction', 'mainstream'],
       ]
 
       rows = RummagerDataPresenter.present_content(batch_data)
@@ -51,7 +51,6 @@ module Import
             'link' => "/government/organisations/test-org"
           },
         ],
-        'document_type' => 'edition',
         'format' => 'transaction',
         'index' => 'mainstream',
       }

--- a/spec/integration/check_runner_spec.rb
+++ b/spec/integration/check_runner_spec.rb
@@ -129,7 +129,6 @@ RummagerRedirects
             }
           ],
           index: "mainstream",
-          document_type: "edition"
         }
       ]
     )


### PR DESCRIPTION
Rummager returns a `document_type` by default, but the meaning of this field is very vague. To avoid confusion with the publishing-api document_type it's better to remove it here completely.
