### PR TITLE
Replace publishing-api format with document type

### DIFF
--- a/lib/checks/base_paths_missing_from_rummager.rb
+++ b/lib/checks/base_paths_missing_from_rummager.rb
@@ -11,14 +11,15 @@ module Checks
       SELECT
         pac.content_id,
         pac.publishing_app,
-        pac.format
+        pac.document_type,
+        pac.schema_name
       FROM publishing_api_content pac
       LEFT JOIN rummager_base_path_content_id lookup ON pac.content_id = lookup.content_id
       WHERE lookup.base_path IS NULL
       AND pac.ever_published = 'published_at_least_once'
       SQL
 
-      headers = %w(content_id publishing_app format)
+      headers = %w(content_id publishing_app document_type schema_name)
       rows = @checker_db.execute(query)
       @reporter.create_report(@name, headers, rows)
     end

--- a/lib/checks/links_missing_from_publishing_api.rb
+++ b/lib/checks/links_missing_from_publishing_api.rb
@@ -13,7 +13,8 @@ module Checks
         pal.link_content_id,
         pal.content_id,
         pac.publishing_app,
-        pac.format
+        pac.document_type,
+        pac.schema_name
       FROM publishing_api_link pal
       JOIN publishing_api_content pac ON pal.content_id = pac.content_id
       SQL
@@ -24,7 +25,8 @@ module Checks
         link_lookup.content_id as link_content_id,
         lookup.content_id,
         pac.publishing_app,
-        pac.format
+        pac.document_type,
+        pac.schema_name
       FROM rummager_link rl
       JOIN rummager_base_path_content_id lookup ON lookup.base_path = rl.base_path
       JOIN rummager_base_path_content_id link_lookup ON link_lookup.base_path = rl.link_base_path
@@ -33,7 +35,7 @@ module Checks
 
       publishing_api_missing_links_query = "#{rummager_links_query} EXCEPT #{publishing_api_links_query}"
 
-      headers = %w(link_type link_content_id content_id publishing_app format)
+      headers = %w(link_type link_content_id content_id publishing_app document_type schema_name)
       rows = @checker_db.execute(publishing_api_missing_links_query)
       @reporter.create_report(@name, headers, rows)
     end

--- a/lib/checks/links_missing_from_rummager.rb
+++ b/lib/checks/links_missing_from_rummager.rb
@@ -13,7 +13,8 @@ module Checks
         pal.link_content_id,
         pal.content_id,
         pac.publishing_app,
-        pac.format
+        pac.document_type,
+        pac.schema_name
       FROM publishing_api_link pal
       JOIN publishing_api_content pac ON pal.content_id = pac.content_id
       WHERE pal.link_type IN ('people', 'organisations', 'working_groups', 'topics', 'mainstream_browse_pages')
@@ -26,7 +27,8 @@ module Checks
         link_lookup.content_id as link_content_id,
         lookup.content_id,
         pac.publishing_app,
-        pac.format
+        pac.document_type,
+        pac.schema_name
       FROM rummager_link rl
       JOIN rummager_base_path_content_id lookup ON lookup.base_path = rl.base_path
       JOIN rummager_base_path_content_id link_lookup ON link_lookup.base_path = rl.link_base_path
@@ -35,7 +37,7 @@ module Checks
 
       rummager_missing_links_query = "#{publishing_api_links_query} EXCEPT #{rummager_links_query}"
 
-      headers = %w(link_type link_content_id content_id publishing_app format)
+      headers = %w(link_type link_content_id content_id publishing_app document_type schema_name)
       rows = @checker_db.execute(rummager_missing_links_query)
       @reporter.create_report(@name, headers, rows)
     end

--- a/lib/checks/rummager_redirected_links.rb
+++ b/lib/checks/rummager_redirected_links.rb
@@ -29,7 +29,7 @@ module Checks
       LEFT JOIN publishing_api_content pubapi_document
         ON document_lookup.content_id = pubapi_document.content_id
 
-      WHERE pubapi_link.format = 'redirect'
+      WHERE pubapi_link.schema_name = 'redirect'
       SQL
 
       headers = %w(

--- a/lib/checks/rummager_redirects.rb
+++ b/lib/checks/rummager_redirects.rb
@@ -15,7 +15,7 @@ module Checks
       FROM rummager_link rl
       JOIN rummager_base_path_content_id lookup ON lookup.base_path = rl.base_path
       JOIN publishing_api_content pac ON lookup.content_id = pac.content_id
-      WHERE pac.format = 'redirect'
+      WHERE pac.schema_name = 'redirect'
       SQL
 
       headers = %w(content_id base_path publishing_app)

--- a/lib/import/publishing_api_data_presenter.rb
+++ b/lib/import/publishing_api_data_presenter.rb
@@ -3,10 +3,10 @@ module Import
     def self.present_content(content_id_data)
       # assumptions:
       # a content_id always has at least one content_item
-      # each content_item of a given content_id has the same format and publishing_app
+      # each content_item of a given content_id has the same schema and publishing_app
 
       exemplar = content_id_data['content_items'].first
-      [content_id_data['content_id'], exemplar['publishing_app'], exemplar['format'], ever_published(content_id_data)]
+      [content_id_data['content_id'], exemplar['publishing_app'], exemplar['document_type'], exemplar['schema_name'], ever_published(content_id_data)]
     end
 
     def self.present_links(content_id_data)

--- a/lib/import/publishing_api_importer.rb
+++ b/lib/import/publishing_api_importer.rb
@@ -31,7 +31,8 @@ module Import
         columns: [
           'content_id text',
           'publishing_app text',
-          'format text',
+          'document_type text',
+          'schema_name text',
           'ever_published text',
         ],
         index: ['content_id'],
@@ -75,7 +76,7 @@ module Import
     def import_content(row)
       @checker_db.insert_batch(
         table_name: 'publishing_api_content',
-        column_names: %w(content_id publishing_app format ever_published),
+        column_names: %w(content_id publishing_app document_type schema_name ever_published),
         rows: row
       )
     end

--- a/spec/import/publishing_api_data_presenter_spec.rb
+++ b/spec/import/publishing_api_data_presenter_spec.rb
@@ -19,7 +19,7 @@ module Import
     it "presents content from publishing-api in a form suitable for insertion in the local sqlite db" do
       content_id_data = test_data_example
 
-      expected_row = ["00015d3f-e7d9-48e8-95ff-ac3f7fa07be3", "whitehall", "statistics_announcement", 'published_at_least_once']
+      expected_row = ["00015d3f-e7d9-48e8-95ff-ac3f7fa07be3", "whitehall", "statistics_announcement", "statistics_announcement", 'published_at_least_once']
 
       row = PublishingApiDataPresenter.present_content(content_id_data)
 
@@ -34,7 +34,8 @@ module Import
           'content_items' => [
               {
                   'base_path' => "/government/statistics/announcements/some-statistics-page",
-                  'format' => "statistics_announcement",
+                  'document_type' => "statistics_announcement",
+                  'schema_name' => "statistics_announcement",
                   'locale' => "en",
                   'publishing_app' => "whitehall",
                   'state' => "published",
@@ -42,7 +43,8 @@ module Import
               },
               {
                   'base_path' => "/government/statistics/announcements/another-statistics-page",
-                  'format' => "statistics_announcement",
+                  'document_type' => "statistics_announcement",
+                  'schema_name' => "statistics_announcement",
                   'locale' => "en",
                   'publishing_app' => "whitehall",
                   'state' => "superseded",

--- a/spec/integration/check_runner_spec.rb
+++ b/spec/integration/check_runner_spec.rb
@@ -52,8 +52,8 @@ RummagerRedirects
   end
 
   def check_csv_content
-    expect(read_csv('LinksMissingFromRummager.csv')).to eq("link_type,link_content_id,content_id,publishing_app,format\norganisations,42,1,app1,format1\n")
-    expect(read_csv('BasePathsMissingFromRummager.csv')).to eq("content_id,publishing_app,format\n1,app1,format1\n")
+    expect(read_csv('LinksMissingFromRummager.csv')).to eq("link_type,link_content_id,content_id,publishing_app,document_type,schema_name\norganisations,42,1,app1,my-document-type,my-schema-name\n")
+    expect(read_csv('BasePathsMissingFromRummager.csv')).to eq("content_id,publishing_app,document_type,schema_name\n1,app1,my-document-type,my-schema-name\n")
   end
 
   def read_csv(csv_filename)
@@ -73,7 +73,8 @@ RummagerRedirects
               locale: "en",
               base_path: "/base_path_1",
               publishing_app: "app1",
-              format: "format1",
+              document_type: "my-document-type",
+              schema_name: "my-schema-name",
               user_facing_version: "3",
               state: "published"
             }],
@@ -113,7 +114,7 @@ RummagerRedirects
       response_total: 1,
       response_results: [
         {
-          format: "format2",
+          format: "my-rummager-format",
           link: "/base_path_2",
           organisations: [
             {

--- a/whitelist.yml
+++ b/whitelist.yml
@@ -19,41 +19,41 @@
 BasePathsMissingFromRummager:
   rules:
     - predicate:
-      - format: 'email_alert_signup'
-      - format: 'special_route'
-      - format: 'financial_releases_geoblocker'
-      - format: 'finder_email_signup'
-      - format: 'financial_release'
-      - format: 'financial_releases_campaign'
+      - schema_name: 'email_alert_signup'
+      - schema_name: 'special_route'
+      - schema_name: 'financial_releases_geoblocker'
+      - schema_name: 'finder_email_signup'
+      - schema_name: 'financial_release'
+      - schema_name: 'financial_releases_campaign'
       expiry: '3000-01-01'
       reason: "Format doesn't contain searchable information"
 
     - predicate:
-      - format: 'redirect'
-      - format: 'gone'
-      - format: 'unpublishing'
+      - schema_name: 'redirect'
+      - schema_name: 'gone'
+      - schema_name: 'unpublishing'
       expiry: '3000-01-01'
       reason: "Rummager indexes the new link, not the old one"
 
     - predicate:
-      - format: 'taxon'
+      - schema_name: 'taxon'
       expiry: '2017-01-01'
       reason: "Taxon is a new thing and shouldn't be visible to users"
 
     - predicate:
-      - format: 'topic'
+      - schema_name: 'topic'
         content_id: '76e9abe7-dac8-49f0-bb5e-53e4b0d2cdba'
       expiry: '3000-01-01'
       reason: "Topic main page"
 
     - predicate:
       - publishing_app: 'whitehall'
-        format: 'html_publication'
+        schema_name: 'html_publication'
       expiry: '2017-01-01'
       reason: "We don't currently index html attachments (but perhaps we should?)"
 
     - predicate:
-      - format: 'inside-government-link'
+      - schema_name: 'inside-government-link'
       expiry: '3000-01-01'
       reason: "These are internal links added by recommended links. Don't belong in Publishing API."
 
@@ -131,36 +131,36 @@ LinksMissingFromRummager:
       reason: "We're not going to look at people links for a long time - let's reassess next year"
 
     - predicate:
-      - format: 'email_alert_signup'
-      - format: 'special_route'
-      - format: 'financial_releases_geoblocker'
-      - format: 'finder_email_signup'
-      - format: 'financial_release'
-      - format: 'financial_releases_campaign'
+      - schema_name: 'email_alert_signup'
+      - schema_name: 'special_route'
+      - schema_name: 'financial_releases_geoblocker'
+      - schema_name: 'finder_email_signup'
+      - schema_name: 'financial_release'
+      - schema_name: 'financial_releases_campaign'
       expiry: '3000-01-01'
       reason: "Format doesn't contain searchable information"
 
     - predicate:
-      - format: 'redirect'
-      - format: 'gone'
-      - format: 'unpublishing'
+      - schema_name: 'redirect'
+      - schema_name: 'gone'
+      - schema_name: 'unpublishing'
       expiry: '3000-01-01'
       reason: "Rummager indexes the new link, not the old one"
 
     - predicate:
-      - format: 'taxon'
+      - schema_name: 'taxon'
       expiry: '2017-01-01'
       reason: "Taxon is a new thing and shouldn't be visible to users"
 
     - predicate:
-      - format: 'topic'
+      - schema_name: 'topic'
         content_id: '76e9abe7-dac8-49f0-bb5e-53e4b0d2cdba'
       expiry: '3000-01-01'
       reason: "Topic main page"
 
     - predicate:
       - publishing_app: 'whitehall'
-        format: 'html_publication'
+        schema_name: 'html_publication'
       expiry: '2017-01-01'
       reason: "We don't currently index html attachments (but perhaps we should?)"
 
@@ -196,17 +196,17 @@ LinksMissingFromPublishingApi:
       expiry: '2016-06-14'
       reason: 'https://trello.com/c/csue5VYU/646-specialist-publisher-manuals-have-missing-organisations-in-publishing-api'
     - predicate:
-      - format: 'placeholder_organisation'
+      - schema_name: 'placeholder_organisation'
         link_type: 'organisations'
       expiry: '2016-07-01'
       reason: 'Organisations are tagged to itself. https://trello.com/c/aOTMr3WJ'
     - predicate:
-      - format: 'hmrc_manual_section'
+      - schema_name: 'hmrc_manual_section'
         link_type: 'organisations'
       expiry: '2016-07-01'
       reason: "HMRC Manuals API doesn't tag manual sections yet: https://trello.com/c/ofpGSyzO"
     - predicate:
-      - format: redirect
+      - schema_name: redirect
       expiry: '3000-01-01'
       reason: We shouldn't index redirects in search.
 


### PR DESCRIPTION
`document_type` and `schema_name` are replacing format. By importing those we can use `document_type` in the whitelist.

https://trello.com/c/M0CimIHQ

https://github.com/alphagov/publishing-api/pull/347 has added the fields to the API response.
