### PR TITLE
Whitelist business support pages

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -63,9 +63,11 @@ BasePathsMissingFromRummager:
       reason: 'Investigating: https://trello.com/c/xARBi6HF'
 
     - predicate:
-      - publishing_app: 'publisher'
-      expiry: '2016-07-01'
-      reason: 'Investigating: https://trello.com/c/M0CimIHQ'
+      - document_type: 'business_support'
+      expiry: '3000-01-01'
+      reason: | Business Support pages have always been kept out of the search
+        index. This is probably because users should find these pages via the
+        business support finder (https://www.gov.uk/business-finance-support-finder)
 
     - predicate:
       - publishing_app: 'collections-publisher'


### PR DESCRIPTION
Now that we have `document_type` to play with (https://github.com/alphagov/finding-things-migration-checker/pull/44), we can replace this whitelist entry with a very specific one.

https://trello.com/c/M0CimIHQ
