### PR TITLE
Correct the order of the Rummager import

### DIFF
--- a/lib/import/rummager_importer.rb
+++ b/lib/import/rummager_importer.rb
@@ -79,6 +79,7 @@ module Import
     def do_request(offset)
       Services.rummager.unified_search(
         fields: %w(link content_id format mainstream_browse_pages specialist_sectors organisations policy_groups people),
+        order: 'public_timestamp',
         start: offset,
         count: BATCH_SIZE,
         debug: 'include_withdrawn'


### PR DESCRIPTION
The order of the results for the rummager import was probably
not deterministic. The default ordering is by 'popularity', and we're
not sure that that doesn't have a random component.

Let's order by timestamp instead (we can't order by multiple fields).

See https://trello.com/c/PtYjhVR8
