### PR TITLE
Add sigdump gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem 'thread'
 gem 'govuk-lint', '~> 1.1.0'
 gem 'rspec'
 gem 'webmock'
+
+gem 'sigdump'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
     scss_lint (0.44.0)
       rake (~> 10.0)
       sass (~> 3.4.15)
+    sigdump (0.2.4)
     sqlite3 (1.3.11)
     thread (0.2.2)
     unf (0.1.4)
@@ -84,6 +85,7 @@ DEPENDENCIES
   gds-api-adapters (~> 30.6.0)
   govuk-lint (~> 1.1.0)
   rspec
+  sigdump
   sqlite3
   thread
   webmock

--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -1,3 +1,5 @@
+require 'sigdump/setup'
+
 require 'sqlite3'
 require 'gds_api/rummager'
 require 'gds_api/publishing_api_v2'


### PR DESCRIPTION
# With the default config, which we are using, sigdump traps

the SIGCONT signal and writes debug info including a thread dump
to `/tmp/sigdump-<pid>.log`

We'll use this to help diagnose hangs in the jenkins checker job.
