### PR TITLE
Remove thread pools from importers

### DIFF
--- a/lib/import/publishing_api_importer.rb
+++ b/lib/import/publishing_api_importer.rb
@@ -2,7 +2,6 @@ module Import
   class PublishingApiImporter
     def initialize(checker_db, progress_reporter)
       @checker_db = checker_db
-      @thread_pool = Thread.pool(1)
       @progress_reporter = progress_reporter
     end
 
@@ -10,13 +9,9 @@ module Import
       create_publishing_api_tables
 
       import_publishing_api_batches do |batch_data|
-        @thread_pool.process {
-          import_content(batch_data.map { |content_id_data| Import::PublishingApiDataPresenter.present_content(content_id_data) })
-          import_content_links(batch_data.flat_map { |content_id_data| Import::PublishingApiDataPresenter.present_links(content_id_data) })
-        }
+        import_content(batch_data.map { |content_id_data| Import::PublishingApiDataPresenter.present_content(content_id_data) })
+        import_content_links(batch_data.flat_map { |content_id_data| Import::PublishingApiDataPresenter.present_links(content_id_data) })
       end
-      @progress_reporter.message('publishing api import', "waiting for #{@thread_pool.backlog} remaining tasks to complete")
-      @thread_pool.shutdown
       @progress_reporter.message('publishing api import', 'finished')
     end
 


### PR DESCRIPTION
We've observed the checker starving its own import of publishing-api
content by sending many requests for the content_id lookup
during the rummager import.
This doesn't always happen but it is not worth the effort to investigate.
We've deployed to jenkins on integration, so we now care
more about consistency than speed.
Since the resources in integration are different from those on
our laptops, we shouldn't expect the execution model used
during dev to carry over particularly well.
We should also consider other users of the integration environment.
