### PR TITLE
Ignore withdrawn items when checking what is missing from publishing-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ in Jenkins and still keep the job green even though there may be some known prob
 
 Each check's purpose and way of working should be described in the [checks readme](lib/checks/README.md)
 
+Whitelist entries have a reason for existing and an expiry date.
+Expired entries are reported as errors.
+
 ### Dependencies
 
 - [publishing api](https://github.com/alphagov/publishing-api)

--- a/lib/checks/README.md
+++ b/lib/checks/README.md
@@ -23,6 +23,7 @@ This check finds content present in Rummager for which the base_path doesn't map
 The assumption is that anything present in Rummager should be published.
 Our proxy for 'being published' is that the `/lookup-by-base-path` endpoint in Publishing API finds a content_id.
 Recommended links are excluded.
+Withdrawn items are excluded, because the content_id lookup does not guarantee to find a content_id for them.
 
 ### BasePathsMissingFromRummager
 
@@ -50,13 +51,6 @@ The assumption is that links should always be in sync.
 
 This check finds links present in Publishing API which are not present in Rummager.
 The assumption is that links should always be in sync.
-
-### ExpiredWhitelistEntries
-
-This check doesn't check anything about Rummager or Publishing API.
-Instead, it reports on whitelist entries which have expired.
-This is so that when the checks are running automatically in Jenkins, we are eventually reminded of discrepancies we previously whitelisted.
-We should provide a reason and a sensible recheck time when we add a whitelist entry.
 
 # RummagerRedirects
 

--- a/lib/checks/base_paths_missing_from_publishing_api.rb
+++ b/lib/checks/base_paths_missing_from_publishing_api.rb
@@ -16,6 +16,7 @@ module Checks
       LEFT JOIN rummager_base_path_content_id lookup ON rc.base_path = lookup.base_path
       WHERE lookup.content_id IS NULL
       AND format NOT IN ('recommended-link')
+      AND rc.is_withdrawn != 'withdrawn'
       SQL
 
       headers = %w(base_path format index)

--- a/lib/import/rummager_data_presenter.rb
+++ b/lib/import/rummager_data_presenter.rb
@@ -7,6 +7,7 @@ module Import
           item['content_id'],
           item['format'],
           item['index'],
+          item['is_withdrawn'] == 'true' ? 'withdrawn' : 'not_withdrawn',
         ]
       end
     end

--- a/lib/import/rummager_importer.rb
+++ b/lib/import/rummager_importer.rb
@@ -32,6 +32,7 @@ module Import
           'content_id text',
           'format text',
           'rummager_index text',
+          'is_withdrawn text',
         ],
         index: ['base_path']
       )
@@ -72,7 +73,7 @@ module Import
 
     def do_request(offset)
       Services.rummager.unified_search(
-        fields: %w(link content_id format mainstream_browse_pages specialist_sectors organisations policy_groups people),
+        fields: %w(link content_id format is_withdrawn mainstream_browse_pages specialist_sectors organisations policy_groups people),
         order: 'public_timestamp',
         start: offset,
         count: BATCH_SIZE,
@@ -83,7 +84,7 @@ module Import
     def import_content(rows)
       @checker_db.insert_batch(
         table_name: 'rummager_content',
-        column_names: %w(base_path content_id format rummager_index),
+        column_names: %w(base_path content_id format rummager_index is_withdrawn),
         rows: rows
       )
     end

--- a/spec/import/rummager_data_presenter_spec.rb
+++ b/spec/import/rummager_data_presenter_spec.rb
@@ -20,7 +20,7 @@ module Import
       batch_data = [test_data_example]
 
       expected_rows = [
-          ['/vehicle-tax', nil, 'transaction', 'mainstream'],
+          ['/vehicle-tax', nil, 'transaction', 'mainstream', 'not_withdrawn'],
       ]
 
       rows = RummagerDataPresenter.present_content(batch_data)
@@ -52,6 +52,7 @@ module Import
           },
         ],
         'format' => 'transaction',
+        'is_withdrawn' => 'false',
         'index' => 'mainstream',
       }
     end


### PR DESCRIPTION
We cannot link rummager base paths to pubilshing-api content ids
when the item in question is withdrawn, because the lookup by
base path endpoint only returns published items.

We still need to include withdrawn items in the rummager import
since we need to prevent false positives in the opposite check.

So, this PR includes the is_withdrawn field from rummager and examines it
in the single check where it has to be used as a filter.

@davidslv and @benhyland
