### PR TITLE
Clarify misleading whitelist entry

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -250,4 +250,4 @@ RummagerRedirects:
     - predicate:
       - publishing_app: 'service-manual-publisher'
       expiry: '2016-08-14'
-      reason: "We don't think any service manual content has made it into publishing-api yet - it's being rewritten"
+      reason: "Service manual is being rewritten. Redirects are sent to publishing api, but service manual publisher does not remove the old link from rummager. https://trello.com/c/oDkd28x5/649-items-not-getting-updated-in-rummager-when-redirected-in-publishing-api"


### PR DESCRIPTION
Some service manual is in publishing api, eg
https://www.gov.uk/api/content/service-manual/agile/quality.html

But service manual publisher never removes old links from rummager.

https://trello.com/c/oDkd28x5/649-items-not-getting-updated-in-rummager-when-redirected-in-publishing-api
