### PR TITLE
Report unused whitelist entries

### DIFF
--- a/lib/reporting/check_reporter.rb
+++ b/lib/reporting/check_reporter.rb
@@ -5,8 +5,8 @@ module Reporting
     end
 
     def create_report(name, headers, candidate_rows)
-      whitelist_function = @whitelist.get_whitelist_function(name, headers)
-      rows = candidate_rows.reject(&whitelist_function)
+      whitelister = @whitelist.get_whitelister(name, headers)
+      rows = candidate_rows.reject(&whitelister.whitelist_function)
       Reporting::Report.new(
         name: name,
         success: rows.empty?,

--- a/lib/reporting/check_reporter.rb
+++ b/lib/reporting/check_reporter.rb
@@ -7,12 +7,14 @@ module Reporting
     def create_report(name, headers, candidate_rows)
       whitelister = @whitelist.get_whitelister(name, headers)
       rows = candidate_rows.reject(&whitelister.whitelist_function)
+      unused_whitelist_entries = whitelister.unused_entries
       Reporting::Report.new(
         name: name,
         success: rows.empty?,
         summary: "#{name} report: found #{rows.size} (#{candidate_rows.size - rows.size} whitelisted)",
         csv: generate_csv(headers, rows),
         csv_including_whitelisted_rows: generate_csv(headers, candidate_rows),
+        unused_whitelist_entries: unused_whitelist_entries,
       )
     end
 
@@ -34,16 +36,17 @@ module Reporting
 
 
   class Report
-    attr_reader :name, :success, :summary, :csv, :csv_including_whitelisted_rows
+    attr_reader :name, :success, :summary, :csv, :csv_including_whitelisted_rows, :unused_whitelist_entries
 
     private_class_method :initialize
 
-    def initialize(name:, success:, summary:, csv:, csv_including_whitelisted_rows:)
+    def initialize(name:, success:, summary:, csv:, csv_including_whitelisted_rows:, unused_whitelist_entries:)
       @name = name
       @success = success
       @summary = summary
       @csv = csv
       @csv_including_whitelisted_rows = csv_including_whitelisted_rows
+      @unused_whitelist_entries = unused_whitelist_entries
     end
   end
 end

--- a/lib/whitelist/whitelist.rb
+++ b/lib/whitelist/whitelist.rb
@@ -81,6 +81,10 @@ private
       Predicate.predicate_for(headers, @conj_hash_arr)
     end
 
+    def inspect
+      "{predicate: #{@conj_hash_arr}, reason: '#{@reason}', expiry: '#{@expiry}'}"
+    end
+
     def self.predicate_for(headers, conj_hash_arr)
       conjunctions = conj_hash_arr.map { |conj_hash| Predicate.conjunction_for(headers, conj_hash) }
       lambda { |row| conjunctions.any? { |c| c.call(row) } }


### PR DESCRIPTION
We now perform the whitelisting in the context of a mutable
`whitelister` object which records which entries were
used by its whitelist function applications.
It can then be queried after application to discover unused entries.

Then, emit the new contents of the report when we run the checks,
so we can see output in jenkins to help us maintain the whitelist.
Note that we don't fail the job if the whitelist has unused entries.
