### PR TITLE
Remove obsolete filters

### DIFF
--- a/lib/checks/rummager_content_missing_from_publishing_api.rb
+++ b/lib/checks/rummager_content_missing_from_publishing_api.rb
@@ -15,8 +15,6 @@ module Checks
       FROM rummager_content rc
       LEFT JOIN rummager_base_path_content_id lookup ON rc.base_path = lookup.base_path
       WHERE lookup.content_id IS NULL
-      AND format NOT IN ('recommended-link')
-      AND rc.is_withdrawn != 'withdrawn'
       SQL
 
       headers = %w(base_path format index)

--- a/whitelist.yml
+++ b/whitelist.yml
@@ -127,6 +127,11 @@ RummagerContentMissingFromPublishingApi:
       reason: "These are internal links added by recommended links. Don't belong in Publishing API."
 
     - predicate:
+      - format: recommended-link
+      expiry: '3000-01-01'
+      reason: "Recommended links don't belong in Publishing API."
+
+    - predicate:
       - format: publication
         index: government
       expiry: '2016-07-01'


### PR DESCRIPTION
The recommended-link filter should be handled by the whitelist.
The withdrawn content filter is no longer needed once
https://github.com/alphagov/publishing-api/pull/359
is merged.
