### PR TITLE
Whitelist topics link targets missing

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -199,8 +199,9 @@ RummagerLinkTargetsMissingFromRummager:
 
     - predicate:
       - link_type: 'organisations'
+      - link_type: 'topics'
       expiry: '2016-08-01'
-      reason: 'It seems we have a truckload of false positives for organisations. https://trello.com/c/6pyJIP1D'
+      reason: 'It seems we have a truckload of false positives for organisations and topics. https://trello.com/c/6pyJIP1D'
 
 LinksMissingFromPublishingApi:
   rules:


### PR DESCRIPTION
The checks are unreliable at the moment and we are seeing many false positives
