### PR TITLE
Whitelist all the things

### DIFF
--- a/whitelist.yml
+++ b/whitelist.yml
@@ -247,7 +247,36 @@ LinksMissingFromPublishingApi:
       - publishing_app: 'publisher'
         content_id: f4b96a38-5247-4afd-b554-8a258a0e8c93
       expiry: '2017-01-01'
-      reason: 'Links deleted in content api. Rummager has historically not removed links. This will be corrected when message queue indexing gets switched on.'
+      reason: 'Links deleted in content api. Rummager has historically not removed links. This may be corrected when rummager content is sourced from the publishing api queue.'
+
+    - predicate:
+      - base_path: '/reporting-road-obstruction'
+        format: 'placeholder'
+        link_base_path: '/browse/housing/recycling-rubbish'
+      - base_path: '/report-debris-motorways-main-road'
+        format: 'placeholder'
+        link_base_path: '/browse/housing/recycling-rubbish'
+      - base_path: '/apply-building-regulation-approval-from-council'
+        format: 'placeholder'
+        link_base_path: '/browse/housing/planning-permission'
+      expiry: '3000-01-01'
+      reason: 'Placeholder content that is redirected. Rummager and publishing api both have the old item, but publishing api never got the links.'
+
+    - predicate:
+      - base_path: '/employee-ownership'
+        link_base_path: '/browse/business/setting-up'
+      - base_path: '/employee-reservist'
+        link_base_path: '/browse/employing-people/payroll'
+      - base_path: '/employee-reservist'
+        link_base_path: '/topic/business-tax/PAYE'
+      - base_path: '/register-biomass-supplier'
+        link_base_path: '/browse/benefits-heating'
+      - base_path: '/hunting'
+        link_base_path: '/browse/environment-countryside'
+      - base_path: '/pedlars-certificate'
+        link_base_path: '/browse/business/setting-up'
+      expiry: '2016-09-01'
+      reason: 'Rummager has some extra links that should be removed. Raising with content team.'
 
     - predicate:
       - publishing_app: 'whitehall'
@@ -256,6 +285,27 @@ LinksMissingFromPublishingApi:
         content_id: 945dd603-4550-4b39-b92d-cb6f2d04be55
       expiry: '2017-01-01'
       reason: 'Some withdrawn documents that lost their links in publishing api. https://trello.com/c/nOhlbdQT/50-withdrawn-reports-no-longer-tagged-to-dfh'
+
+    - predicate:
+      - publishing_app: 'whitehall'
+        link_type: 'topic'
+        base_path: '/government/collections/river-basin-management-plans-update'
+      expiry: '2016-09-01'
+      reason: 'See https://trello.com/c/ouFmYN9S/55-rummager-data-flooded-with-duplicate-tags'
+
+    - predicate:
+      - link_base_path: '/topic/competition/mergers'
+        base_path: '/government/news/cma-opens-consultation-on-reed-elsevier-undertakings'
+      - link_base_path: '/topic/environmental-management/land-management'
+        base_path: '/government/collections/common-land-guidance-for-commons-registration-authorities-and-applicants'
+      expiry: '2017-09-01'
+      reason: 'Redirected content, but not a redirect in publishing api. We can probably ignore this.'
+
+    - predicate:
+      - base_path: '/government/publications/markets-orders-and-undertakings-register'
+      - base_path: '/government/collections/planning-and-economic-development'
+      expiry: '2016-09-01'
+      reason: 'Missing link in publishing api. https://trello.com/c/IsMZN5wj/56-inconsistent-topic-tagging-for-whitehall-content'
 
 RedirectedRummagerContent:
   rules:

--- a/whitelist.yml
+++ b/whitelist.yml
@@ -169,6 +169,34 @@ LinksMissingFromRummager:
       expiry: '2017-06-01'
       reason: "We're not going to look at people links for a long time - let's reassess next year"
 
+    - predicate:
+      - link_type: 'mainstream_browse_pages'
+        base_path: '/pedlars-certificate'
+        link_base_path: '/browse/business/sale-goods-services-data'
+      - link_type: 'mainstream_browse_pages'
+        base_path: '/employee-ownership'
+        link_base_path: '/browse/employing-people/contracts'
+      - link_type: 'mainstream_browse_pages'
+        base_path: '/apply-special-educational-needs-assessment'
+        link_base_path: '/browse/disabilities/equipment'
+      - link_type: 'mainstream_browse_pages'
+        base_path: '/apply-special-educational-needs-assessment'
+        link_base_path: '/browse/births-deaths-marriages/child-adoption'
+      expiry: '2016-09-01'
+      reason: "These links are all missing from rummager. Publishing api is correct. Content team are going to republish."
+
+    - predicate:
+      - link_type: 'mainstream_browse_pages'
+        base_path: '/international-child-abduction'
+        link_base_path: '/browse/abroad/travel-abroad'
+      expiry: '2016-09-01'
+      reason: "This link is missing from rummager but exists in rummager. But the content is withdrawn. We should just remove the old link."
+
+    - predicate:
+      - link_type: 'organisations'
+      expiry: '2016-09-01'
+      reason: "Deal with this after automating the links checker."
+
 RummagerLinkTargetsMissingFromRummager:
   rules:
     - predicate:
@@ -184,8 +212,8 @@ RummagerLinkTargetsMissingFromRummager:
     - predicate:
       - link_type: 'organisations'
       - link_type: 'topics'
-      expiry: '2016-08-01'
-      reason: 'It seems we have a truckload of false positives for organisations and topics. https://trello.com/c/6pyJIP1D'
+      expiry: '2017-06-01'
+      reason: 'It seems we have a truckload of false positives for organisations and topics. Impact: searching by organisation may not be complete. https://trello.com/c/6pyJIP1D'
 
 LinksMissingFromPublishingApi:
   rules:
@@ -220,6 +248,14 @@ LinksMissingFromPublishingApi:
         content_id: f4b96a38-5247-4afd-b554-8a258a0e8c93
       expiry: '2017-01-01'
       reason: 'Links deleted in content api. Rummager has historically not removed links. This will be corrected when message queue indexing gets switched on.'
+
+    - predicate:
+      - publishing_app: 'whitehall'
+        content_id: 932dbd8c-12c5-46a6-8ca2-bc42113ae291
+      - publishing_app: 'whitehall'
+        content_id: 945dd603-4550-4b39-b92d-cb6f2d04be55
+      expiry: '2017-01-01'
+      reason: 'Some withdrawn documents that lost their links in publishing api. https://trello.com/c/nOhlbdQT/50-withdrawn-reports-no-longer-tagged-to-dfh'
 
 RedirectedRummagerContent:
   rules:


### PR DESCRIPTION
We have a few pages that are appearing in the wrong mainstream browse section.

We also have a lot of content tagged to highway-code-road-safety that don't have
the link expanded properly in the content store. We think this might be related to an
earlier incident affecting to that content (the browse page).

There are other problems with consistency of organisation tagging but I'm deferring
this until we get monitoring in place, because it could take a long time to debug
these.
